### PR TITLE
Fix README and its CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ The library can be run on the command line supporting all API functions. Use the
 usage information:
 
 ```shell
-python3 -m deepl --help
+deepl --help
 ```
 
 The CLI requires your DeepL authentication key specified either as the `DEEPL_AUTH_KEY` environment variable, or using
 the `--auth-key` option, for example:
 
 ```shell
-python3 -m deepl --auth-key=YOUR_AUTH_KEY usage
+deepl --auth-key=YOUR_AUTH_KEY usage
 ```
 
 Note that the `--auth-key` argument must appear *before* the command argument. The recognized commands are:
@@ -169,7 +169,7 @@ Note that the `--auth-key` argument must appear *before* the command argument. T
 For example, to translate text:
 
 ```shell
-python3 -m deepl --auth-key=YOUR_AUTH_KEY text --to=DE "Text to be translated."
+deepl --auth-key=YOUR_AUTH_KEY text --to=DE "Text to be translated."
 ```
 
 Wrap text arguments in quotes to prevent the shell from splitting sentences into words.

--- a/README.md
+++ b/README.md
@@ -13,26 +13,29 @@ The DeepL Python library offers a convenient way for applications written in Pyt
 intend to support all API functions with the library, though support for new features may be added to the library after
 they’re added to the API.
 
+## Getting an authentication key
 
-## Getting an authentication key 
-
-To use the DeepL Python Library, you'll need an API authentication key. To get a key, [please create an account here](https://www.deepl.com/pro?utm_source=github&utm_medium=github-python-readme#developer). You can translate up to 500,000 characters/month for free. 
+To use the DeepL Python Library, you'll need an API authentication key. To get a key, [please create an account here](https://www.deepl.com/pro?utm_source=github&utm_medium=github-python-readme#developer). You can translate up to 500,000 characters/month for free.
 
 After you have created an account, you can find your API authentication key on your [DeepL Pro Account](https://www.deepl.com/pro-account/?utm_source=github&utm_medium=github-python-readme).
 
 ## Installation
+
 The library can be installed from [PyPI](https://pypi.org/project/deepl/) using pip:
+
 ```shell
 pip install --upgrade deepl
 ```
 
 If you need to modify this source code, install the dependencies using poetry:
+
 ```shell
 poetry install
 ```
 
 ### Requirements
-The library is tested with Python versions 3.6 to 3.10. 
+
+The library is tested with Python versions 3.6 to 3.10.
 
 The `requests` module is used to perform HTTP requests; the minimum is version 2.0.
 
@@ -59,7 +62,7 @@ print(result[0].detected_source_lang)  # "JA"
 print(result[1].text)  # "How are you?"
 print(result[1].detected_source_lang)  # "ES"
 
-# Translate a formal document from English to German 
+# Translate a formal document from English to German
 translator.translate_document_from_filepath(
     "Instruction Manual.docx",
     "Bedienungsanleitung.docx",
@@ -107,14 +110,17 @@ for language in translator.get_target_languages():
 ```
 
 ### Exceptions
+
 All module functions may raise `deepl.DeepLException` or one of its subclasses.
-If invalid arguments are provided, they may raise the standard exceptions `ValueError` and `TypeError`. 
+If invalid arguments are provided, they may raise the standard exceptions `ValueError` and `TypeError`.
 
 ### Configuration
 
 #### Logging
+
 Logging can be enabled to see the HTTP-requests sent and responses received by the library. Enable and control logging
 using Python's logging module, for example:
+
 ```python
 import logging
 logging.basicConfig()
@@ -122,7 +128,9 @@ logging.getLogger('deepl').setLevel(logging.DEBUG)
 ```
 
 #### Proxy configuration
+
 You can configure a proxy by specifying the `proxy` argument when creating a `deepl.Translator`:
+
 ```python
 proxy = "http://user:pass@10.10.1.10:3128"
 translator = deepl.Translator(..., proxy=proxy)
@@ -133,16 +141,21 @@ The proxy argument is passed to the underlying `requests` session,
 to proxy URLs is also accepted.
 
 ## Command Line Interface
-The library can be run on the command line supporting all API functions. Use the `--help` option for 
+
+The library can be run on the command line supporting all API functions. Use the `--help` option for
 usage information:
+
 ```shell
 python3 -m deepl --help
 ```
+
 The CLI requires your DeepL authentication key specified either as the `DEEPL_AUTH_KEY` environment variable, or using
 the `--auth-key` option, for example:
+
 ```shell
 python3 -m deepl --auth-key=YOUR_AUTH_KEY usage
 ```
+
 Note that the `--auth-key` argument must appear *before* the command argument. The recognized commands are:
 
 | Command   | Description                                            |
@@ -154,16 +167,20 @@ Note that the `--auth-key` argument must appear *before* the command argument. T
 | glossary  | create, list, and remove glossaries                    |
 
 For example, to translate text:
+
 ```shell
 python3 -m deepl --auth-key=YOUR_AUTH_KEY text --to=DE "Text to be translated."
 ```
+
 Wrap text arguments in quotes to prevent the shell from splitting sentences into words.
 
 ## Development
-The test suite depends on [deepl-mock](https://www.github.com/DeepLcom/deepl-mock). Run it in another terminal while executing the tests, using port 3000. Set the mock-server listening port using the environment variable `DEEPL_MOCK_SERVER_PORT`. 
+
+The test suite depends on [deepl-mock](https://www.github.com/DeepLcom/deepl-mock). Run it in another terminal while executing the tests, using port 3000. Set the mock-server listening port using the environment variable `DEEPL_MOCK_SERVER_PORT`.
 
 Execute the tests using `tox`.
 
 ### Issues
+
 If you experience problems using the library, or would like to request a new feature, please create an
-[issue](https://www.github.com/DeepLcom/deepl-python/issues). 
+[issue](https://www.github.com/DeepLcom/deepl-python/issues).


### PR DESCRIPTION
I have fixed:
- Errors of [markdownlint](https://github.com/DavidAnson/markdownlint)
- Usage of CLI
  - `python3 -m deepl ...` -> `deepl ...` 