### PR TITLE
Remove alpha label from context parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,8 @@ arguments are:
   containing the glossary ID, or a `GlossaryInfo` as returned by
   `get_glossary()`.
 - `context`: specifies additional context to influence translations, that is not
-  translated itself. Note this is an **alpha feature**: it may be deprecated at
-  any time, or incur charges if it becomes generally available.
-  See the [API documentation][api-docs-context-param] for more information and
+  translated itself. Characters in the `context` parameter are not counted toward billing.
+  See the [API documentation][api-docs-context-param] for more information and 
   example usage.
 - `tag_handling`: type of tags to parse before translation, options are `'html'`
   and `'xml'`.


### PR DESCRIPTION
The `context` parameter is no longer an alpha feature and is generally available. This PR updates the README to reflect this change.